### PR TITLE
Update querytime, fix model

### DIFF
--- a/project/ConsoleTracker/ConsoleTrackerApp/models.py
+++ b/project/ConsoleTracker/ConsoleTrackerApp/models.py
@@ -15,19 +15,12 @@ class TimeStamp(models.Model):
 class Machine(models.Model):
     name = models.TextField(blank=True, null=False)
     active = models.BooleanField(default=False)
-
     ip = models.GenericIPAddressField(default="127.0.0.1", null=False, unique=True)
-    # TODO (Future User Model will be mapped to a machine
-    # user = models.OneToOneField(
-    #     User,
-    #     on_delete=models.CASCADE,
-    #     foreign_key=True,
-    # )
 
 
 class User(models.Model):
     name = models.TextField(blank=True, null=False)
-    time = models.IntegerField(default=0)
+    time = models.IntegerField(default=0, null=False)
 
 
 class User_uses_machine(models.Model):
@@ -42,9 +35,11 @@ class User_uses_machine(models.Model):
     
 
 # only way to set end_time based on a Users time field
-# only runs on object creation 
 @receiver(post_save, sender=User_uses_machine)
-def calc_end_time(sender, instance,created, **kwargs):
+def on_creation_uses(sender, instance, created, **kwargs):
     if created:
+        instance.machine.active = True
+        instance.machine.save()
+        
         instance.end_time = instance.start_time + timezone.timedelta(seconds=instance.user.time)
         instance.save()

--- a/project/ConsoleTracker/ConsoleTrackerApp/tasks.py
+++ b/project/ConsoleTracker/ConsoleTrackerApp/tasks.py
@@ -22,6 +22,9 @@ def query_time():
 
 		for query in query_set:
 			query.machine.active = False
+			query.machine.save()
+			query.user.time = 0
+			query.user.save()
 			query.expired = True
 			query.save()
 


### PR DESCRIPTION
sets a users time field to 0 when the timer ends, and machine active field now reflects its current state