### PR TITLE
CSS Mobile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "capstone-project",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}

--- a/project/frontend/src/components/MachineCard.css
+++ b/project/frontend/src/components/MachineCard.css
@@ -1,24 +1,11 @@
-.machinecard__container {
+/* .machinecard__container {
     border:1px solid green;
-}
+} */
 
-/* 
-Introduce Spacing Between Each Cards! 
-Untested! 
-*/
 div.machinecard__container {
     padding-top: 25px;
     padding-right: 25px;
     padding-bottom: 25px;
-    padding-left: 25px;
+    padding-left: 25px;   
 }
 
-/* 
-Center the button in cards 
-Unoptimal since it could introduce strange behaviour. It works at the moment regardless 
-*/
-div.card__actions {
-    margin-left: 25%;
-    margin-right: 25%;
-    
-}

--- a/project/frontend/src/components/MachineCard.js
+++ b/project/frontend/src/components/MachineCard.js
@@ -47,7 +47,7 @@ function MachineCard({machineId,name,status,machineType,...props}) {
     // Part Division
     <div className="machinecard__container">
        {name}
-      <Card sx={{ maxWidth: 300 }}>
+      <Card sx={{ maxWidth: 500 }}>
         <CardMedia
           component="img"
           height="100"

--- a/project/frontend/src/components/Overview.css
+++ b/project/frontend/src/components/Overview.css
@@ -1,4 +1,8 @@
 .overview__container {
     border:1px solid green;
+
+    /* Enables wrapping for the objects inside the container (mostly for Machine Cards) */
     display: flex;
+    justify-content: flex-start;
+    flex-wrap: wrap;
 }

--- a/project/frontend/src/components/Timer.css
+++ b/project/frontend/src/components/Timer.css
@@ -10,7 +10,8 @@
 .time {
     margin-top: 10%;
     margin-bottom: 10%;
-    font-size: xx-large;
+    /* Allows for change in font size */
+    font-size: 5.9vw; 
     color: white;
     justify-content: center;
     align-items: center;
@@ -22,6 +23,4 @@
     display: flex;
     margin-top: 10%;
     size: 100px;
-
-    
 }

--- a/project/frontend/src/components/TopMenu.js
+++ b/project/frontend/src/components/TopMenu.js
@@ -1,4 +1,4 @@
-import React, {useState, useEffect} from 'react';
+import React, { useState, useEffect } from 'react';
 import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
@@ -10,103 +10,156 @@ import MenuItem from '@mui/material/MenuItem';
 import Menu from '@mui/material/Menu';
 
 import { useNavigate } from 'react-router-dom';
- 
-import {Link} from "react-router-dom";
+
+import { Link } from "react-router-dom";
+
+// Import components for reactive font size
+// https://mui.com/customization/typography/#responsive-font-sizes
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+
+const theme = createTheme();
+
+// Controls the Console Tracker Font Size
+theme.typography.h3 = {
+  fontSize: '1.2rem',
+  '@media (min-width:600px)': {
+    fontSize: '1.5rem',
+  },
+
+  // If screen width -> 900px, then our fontSize will be 2rem
+  [theme.breakpoints.up('min-width:900px')]: {
+    fontSize: '2rem',
+  },
+};
+
+// Controls the Drop down Menu Test Size
+theme.typography.h6 = {
+  fontSize: '1rem',
+  '@media (min-width:600px)': {
+    fontSize: '1rem',
+  },
+  [theme.breakpoints.up('md')]: {
+    fontSize: '1.5rem',
+  },
+};
 
 
-function TopMenu({auth}) {
+function TopMenu({ auth }) {
 
-    const [anchorEl, setAnchorEl] = useState(true);
-    const open = Boolean(anchorEl);
+  const [anchorEl, setAnchorEl] = useState(true);
+  const open = Boolean(anchorEl);
 
-    const navigate = useNavigate();
-    const pages = [
-      {name:'Home', to:'/'}, 
-      {name:'Game Stations', to:'/machines'}, 
-      {name:'My Timer', to:'/timer'}
-    ];
+  const navigate = useNavigate();
+  const pages = [
+    { name: 'Home', to: '/' },
+    { name: 'Game Stations', to: '/machines' },
+    { name: 'My Timer', to: '/timer' }
+  ];
 
-    const handleClick = (event) => {
-      setAnchorEl(event.currentTarget);
-    };
-    const handleClose = () => {
-      setAnchorEl(null);
-    };
+  const handleClick = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
 
-    const handleLogout = () => {
-        localStorage.removeItem("loginCookie");
-        navigate('/');
-        window.location.reload();
-    };
+  const handleLogout = () => {
+    localStorage.removeItem("loginCookie");
+    navigate('/');
+    window.location.reload();
+  };
 
+  return (
+    <AppBar position="static">
+      <Toolbar>
+        <IconButton
+          size="large"
+          edge="start"
+          color="inherit"
+          aria-label="menu"
+          sx={{ mr: 2 }}
+        >
+          <MenuIcon />
+        </IconButton>
 
-
-    return (
-      <AppBar position="static">
-        <Toolbar>
-          <IconButton
-            size="large"
-            edge="start"
-            color="inherit"
-            aria-label="menu"
-            sx={{ mr: 2 }}
-          >
-            <MenuIcon />
-          </IconButton>
-          <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+        {/* Temporary Fix */}
+        <ThemeProvider theme={theme}>
+          <Typography variant="h3" component="div" sx={{ flexGrow: 1 }}>
             ConsoleTracker
           </Typography>
-          { auth && pages.map((page) => (
-            <Link to={page.to} style={{ textDecoration: 'none' }}>
-              <MenuItem key={page.name} onClick={handleClose}>
-                  <Typography textAlign="center">{page.name}</Typography>
-              </MenuItem>
-            </Link>
-              ))}
-          { !auth && 
+        </ThemeProvider>
+
+        {!auth &&
           <Link to="/login" style={{ textDecoration: 'none' }}>
             <MenuItem key='login'>
-                <Typography textAlign="center">Login</Typography>
-            </MenuItem>   
+              <Typography textAlign="center">Login</Typography>
+            </MenuItem>
           </Link>
-          }
+        }
 
-          {auth && (
-            <div>
-              <IconButton
-                size="large"
-                aria-label="account of current user"
-                aria-controls="menu-appbar"
-                aria-haspopup="true"
-                onClick={handleClick}
-                color="inherit"
-              >
-                <AccountCircle />
-              </IconButton>
-              <Menu
-                id="menu-appbar"
-                anchorEl={anchorEl}
-                anchorOrigin={{
-                  vertical: 'top',
-                  horizontal: 'right',
-                }}
-                keepMounted
-                transformOrigin={{
-                  vertical: 'top',
-                  horizontal: 'right',
-                }}
-                open={open}
-                onClose={handleClose}
-                onClick={handleClose}
-              >
-                <MenuItem onClick={handleClose}>My account</MenuItem>
-                <MenuItem onClick={handleLogout}>Logout</MenuItem>
-              </Menu>
-            </div>
-          )}
-        </Toolbar>
-      </AppBar>
-    )
+        {auth && (
+          <div>
+            <IconButton
+              size="large"
+              aria-label="account of current user"
+              aria-controls="menu-appbar"
+              aria-haspopup="true"
+              onClick={handleClick}
+              color="inherit"
+            >
+              <AccountCircle />
+            </IconButton>
+            <Menu
+              id="menu-appbar"
+              anchorEl={anchorEl}
+              anchorOrigin={{
+                vertical: 'top',
+                horizontal: 'right',
+              }}
+              keepMounted
+              transformOrigin={{
+                vertical: 'top',
+                horizontal: 'right',
+              }}
+              open={open}
+              onClose={handleClose}
+              onClick={handleClose}
+            >
+
+               {/* Temporary Measure */}
+              <MenuItem onClick={handleClose}>
+
+                <Typography textAlign="center" variant='h6'>
+                  My account
+                </Typography>
+
+              </MenuItem>
+             
+              {auth && pages.map((page) => (
+                <Link to={page.to} style={{ textDecoration: 'none' }}>
+                  <MenuItem key={page.name} onClick={handleClose}>
+                    <ThemeProvider theme={theme}>
+                      <Typography textAlign="center" variant="h6">
+                        {page.name}
+                        </Typography>
+                    </ThemeProvider>
+                  </MenuItem>
+                </Link>
+              ))}
+
+              <MenuItem onClick={handleLogout}>
+
+                <Typography textAlign="center" variant='h6'>
+                  Logout
+                </Typography>
+
+              </MenuItem>
+            </Menu>
+          </div>
+        )}
+      </Toolbar>
+    </AppBar>
+  )
 }
 
 export default TopMenu


### PR DESCRIPTION
PR V2. Messed up with squashing and ended up deleting my previous work.

Pull Request for --> #139 
A couple of CSS has been made. Change the Nav-bar, from having Home, Game Stations, and My Time into the drop-down box. Should work with others just fine. Should fix the odd behaviour that occurs when shirking the screen dimension to 300~.
![image](https://user-images.githubusercontent.com/60308758/153540648-72e99c8d-1e18-44a0-8081-504ce22d2760.png)
VVVV
![image](https://user-images.githubusercontent.com/60308758/153540059-2f9d9094-b83d-44cf-909d-45bb10c52575.png)

Did a slight change onto the overview.css where we now allow the machine cards to wrap around the containers, demonstrated below.
![image](https://user-images.githubusercontent.com/60308758/153540251-05c2b029-5e12-44ee-ae49-58ce20b88501.png)

Allow responsive text on the timer text to prevent text-overflow.
![image](https://user-images.githubusercontent.com/60308758/153540287-022aabc3-95f9-4fb4-8389-275e44f1dd5b.png)

Made ConsoleTracker logo be responsive to the dimension. When the dimension gets smaller than the width of 600px, then it will shrink a bit.  
![image](https://user-images.githubusercontent.com/60308758/153540509-2cd9c581-4e46-4c06-a336-bef62269ca26.png)


Left the My account/Home page alone since there's nothing I need to spruce up a bit.
![image](https://user-images.githubusercontent.com/60308758/153540353-0c3ce288-fb12-412f-b9cc-6cd9c403dda3.png)



