### PR TITLE
Listener and Update Time Value Upon Request

### DIFF
--- a/project/ConsoleTracker/ConsoleTracker/urls.py
+++ b/project/ConsoleTracker/ConsoleTracker/urls.py
@@ -15,7 +15,7 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
-from ConsoleTrackerApp import views, tasks
+from ConsoleTrackerApp import views, tasks, InternalSocketListener
 from django.conf import settings
 from django.conf.urls.static import static
 
@@ -30,3 +30,6 @@ urlpatterns = [
 
 # runs the time checking background task at startup
 tasks.start_query_daemon()
+
+# run listener in the background for requests from external system
+InternalSocketListener.start_listener_daemon()

--- a/project/ConsoleTracker/ConsoleTrackerApp/InternalSocketListener.py
+++ b/project/ConsoleTracker/ConsoleTrackerApp/InternalSocketListener.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+import asyncio
+import json
+import socket
+import sys
+from threading import Thread
+
+from .tasks import update_user_time
+
+HOST = '127.0.0.1'  # The server's hostname or IP address
+PORT = 5073  # The port used by the server
+
+
+def listen():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.connect((HOST, PORT))
+        while True:
+            data = s.recv(1024)
+            if data:
+                data = json.loads(data.decode())
+                messageType = int(data["messageType"])
+                # Check for message type
+                if messageType == 1:  # Update time request
+                    timeBalance = int(data["timeBalance"])
+                    username = data["username"]
+                    print("Update time request")
+                    update_user_time(username, timeBalance)
+                elif messageType == 2:  # Ping request
+                    print("Ping request")
+
+
+def start_listener_daemon():
+    # Background thread for the listener
+    if sys.version_info[0] == 3 and sys.version_info[1] >= 8 and sys.platform.startswith(
+            'win'):  # windows bug https://github.com/encode/httpx/issues/914
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+    t = Thread(target=listen)
+    t.daemon = True
+    t.start()

--- a/project/ConsoleTracker/ConsoleTrackerApp/dummyRequest.py
+++ b/project/ConsoleTracker/ConsoleTrackerApp/dummyRequest.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import socket
+from argparse import RawTextHelpFormatter
+
+HOST = '127.0.0.1'  # The server's hostname or IP address
+PORT = 5073  # The port used by the server
+
+parser = argparse.ArgumentParser(formatter_class=RawTextHelpFormatter)
+parser.add_argument("-m", "--messageType", help="MessageType to send.")
+parser.add_argument("-u", "--username", help="Username to send.")
+parser.add_argument("-p", "--timeBalance", help="timeBalance to send.")
+args = parser.parse_args()
+
+messageType = 1
+username = "chris354"
+timeBalance = 200
+
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+    s.connect((HOST, PORT))
+    s.sendall("{{\"messageType\": \"{m}\", \"username\": \"{u}\", \"timeBalance\": \"{t}\"}}"
+              .format(m=messageType, u=username, t=timeBalance).encode())
+    print("Sent dummy request with username : " + username + ", timeBalance : " + str(timeBalance))

--- a/project/ConsoleTracker/ConsoleTrackerApp/tasks.py
+++ b/project/ConsoleTracker/ConsoleTrackerApp/tasks.py
@@ -1,5 +1,5 @@
 from tracemalloc import start
-from .models import Machine, User_uses_machine
+from .models import Machine, User_uses_machine, User
 from .scripts.SwitchScript import ConsoleSwitch
 from .InternalSocketConnect import InternalSocket
 from .notifications import sendSMS, NOTIF_TIMES
@@ -39,6 +39,14 @@ def switch_on(ip):
 # runs the update time function
 def update_time(socket, username, time):
     return socket.update_time(username, time)
+
+
+# Updates a users time upon request form opus
+def update_user_time(username, new_time):
+    user = User.objects.get(username=username)
+    if user is not None:
+        user.time = new_time
+        user.save()
 
 
 # thread to update the time balance of the user


### PR DESCRIPTION
Added listening socket for external client requests in the background and updated user model time upon each successful request

To test the changes
1. Run the **ServerSocket.py** file
2. Go to the app dir and run **python manage.py runserver**
3. Go to the admin page in **http://127.0.0.1:8000/admin** and log in
4. Create a new user object with these values ![pic1](https://user-images.githubusercontent.com/46385457/155822296-1833c9dd-75fa-4ac9-936e-6a1f26e491f9.PNG)
5. Run the **dummyRequest.py** file. This will simulate an update time request from opus. You should see the message sent successfully if it prints ![pic3](https://user-images.githubusercontent.com/46385457/155822363-ed619e38-e414-4393-87c0-768d50d1942a.PNG)
6. Finally check back on the user object you created earlier and you should see the time value updated ![pic2](https://user-images.githubusercontent.com/46385457/155822348-17abe3c1-2c2a-419c-8373-1d13b1d4548e.PNG)
 