### PR TITLE
Updated socket to allow communication both ways

### DIFF
--- a/project/ConsoleTracker/ConsoleTrackerApp/InternalSocketConnect.py
+++ b/project/ConsoleTracker/ConsoleTrackerApp/InternalSocketConnect.py
@@ -11,7 +11,7 @@ class InternalSocket:
     def send_request(self, username, password):
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.connect((self.host, self.port))
-            s.sendall("{{\"msg\": \"{m}\", \"username\": \"{u}\", \"password\": \"{p}\"}}"
+            s.sendall("{{\"msg\": \"{m}\", \"username\": \"{u}\", \"password\": \"{p}\",\"dest\": \"external\"}}"
                       .format(m="Sending username & password", u=username, p=password).encode())
             data = s.recv(1024)
             data = json.loads(data.decode())

--- a/project/ConsoleTracker/ConsoleTrackerApp/InternalSocketListener.py
+++ b/project/ConsoleTracker/ConsoleTrackerApp/InternalSocketListener.py
@@ -14,6 +14,8 @@ PORT = 5073  # The port used by the server
 def listen():
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.connect((HOST, PORT))
+        initMsg = {"conn_type": 1}
+        s.sendall(json.dumps(initMsg).encode())
         while True:
             data = s.recv(1024)
             if data:

--- a/project/ConsoleTracker/ConsoleTrackerApp/dummyRequest.py
+++ b/project/ConsoleTracker/ConsoleTrackerApp/dummyRequest.py
@@ -20,6 +20,12 @@ timeBalance = 200
 
 with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
     s.connect((HOST, PORT))
-    s.sendall("{{\"messageType\": \"{m}\", \"username\": \"{u}\", \"timeBalance\": \"{t}\"}}"
-              .format(m=messageType, u=username, t=timeBalance).encode())
+    data = {
+        "messageType": messageType,
+        "username": username,
+        "timeBalance": timeBalance,
+        "dest": "django"
+    }
+    s.sendall(json.dumps(data).encode())
+
     print("Sent dummy request with username : " + username + ", timeBalance : " + str(timeBalance))

--- a/project/ConsoleTracker/ConsoleTrackerApp/scripts/ExternalClientSocket.py
+++ b/project/ConsoleTracker/ConsoleTrackerApp/scripts/ExternalClientSocket.py
@@ -31,11 +31,15 @@ time_db = {
 # TODO: refactor to seperate the different messages recieved
 with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
     s.connect((HOST, PORT))
+    initMsg = {"conn_type": 2}
+    s.sendall(json.dumps(initMsg).encode())
     while True:
+        
         data = s.recv(1024)
         if data:
             print(data)
             data = json.loads(data.decode())
+            data["dest"] = "django"
             # seperate the message types
             if data["msg"] == "timer_update":
                 if data["username"] in time_db:

--- a/project/ConsoleTracker/ConsoleTrackerApp/scripts/dummyRequestToExternal.py
+++ b/project/ConsoleTracker/ConsoleTrackerApp/scripts/dummyRequestToExternal.py
@@ -19,8 +19,9 @@ password = args.message if args.message is not None else "greet984;d"  # Dummy P
 
 with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
     s.connect((HOST, PORT))
-    s.sendall("{{\"msg\": \"{m}\", \"username\": \"{u}\", \"password\": \"{p}\"}}"
-              .format(m=msg, u=username, p=password).encode())
+    #s.sendall("{\"conn_type\": 1}".encode())
+    msg = {"msg": msg, "username": username, "password": password, "dest": "external"}
+    s.sendall(json.dumps(msg).encode())
     print("Sent:", msg, username)
     data = s.recv(1024)
     data = json.loads(data.decode())


### PR DESCRIPTION
For sending messages to socket, add the field:
"dest": "external" or "django"
See updates to dummyRequest or dummyRequestToExternal.py for example
Persistent connections need to send initial message:
{
"conn_type": 1(django) or 2(external)
}

To test:
1. run ServerSocket.py
2. run ExternalClienSocket.py & start django server 
3. Run dummyRequest.py (https://github.com/ENG4000-Team-A/capstone-project/pull/172 see here for more info)
4. Run dummyRequestToExternal.py

